### PR TITLE
Make st:include path absolute not relative paths

### DIFF
--- a/src/main/resources/hudson/plugins/project_inheritance/projects/parameters/InheritableStringParameterReferenceDefinition/index.jelly
+++ b/src/main/resources/hudson/plugins/project_inheritance/projects/parameters/InheritableStringParameterReferenceDefinition/index.jelly
@@ -34,5 +34,5 @@ THE SOFTWARE.
 		xmlns:p="/lib/hudson/project"
 >
 	<!-- This file is a carbon-copy of: -->
-	<st:include page="../InheritableStringParameterDefinition/index.jelly" />
+	<st:include page="/hudson/plugins/project_inheritance/projects/parameters/InheritableStringParameterDefinition/index.jelly" />
 </j:jelly>


### PR DESCRIPTION
Relative paths do not work on latest Jenkins running on Windows 7 server. See https://groups.google.com/forum/#!topic/jenkinsci-dev/Wn_bwsQQ2W8

The actual issue I hit was a simple set up (parent project with inheritable parameter, child project with parameter reference to set parameter value), when I attempted to build child project, I got an error message from Jenkins:

Status Code: 500

Exception: org.apache.commons.jelly.JellyTagException: jar:file:/D:/Jenkins/plugins/project-inheritance-1.4.8/WEB-INF/lib/classes.jar!/hudson/plugins/project_inheritance/projects/parameters/InheritableStringParameterReferenceDefinition/index.jelly:37:75: st:include No page found '../InheritableStringParameterDefinition/index.jelly' for class hudson.plugins.project_inheritance.projects.parameters.InheritableStringParameterReferenceDefinition
Stacktrace:
javax.servlet.ServletException: org.apache.commons.jelly.JellyTagException: jar:file:/D:/Jenkins/plugins/project-inheritance-1.4.8/WEB-INF/lib/classes.jar!/hudson/plugins/project_inheritance/projects/parameters/InheritableStringParameterReferenceDefinition/index.jelly:37:75: st:include No page found '../InheritableStringParameterDefinition/index.jelly' for class hudson.plugins.project_inheritance.projects.parameters.InheritableStringParameterReferenceDefinition
    at org.kohsuke.stapler.jelly.JellyRequestDispatcher.forward(JellyRequestDispatcher.java:60)
    at hudson.plugins.project_inheritance.projects.parameters.InheritanceParametersDefinitionProperty._doBuild(InheritanceParametersDefinitionProperty.java:304)
    at hudson.plugins.project_inheritance.projects.InheritanceProject.doBuild(InheritanceProject.java:1283)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at org.kohsuke.stapler.Function$InstanceFunction.invoke(Function.java:297)
    at org.kohsuke.stapler.Function.bindAndInvoke(Function.java:160)
    at org.kohsuke.stapler.Function.bindAndInvokeAndServeResponse(Function.java:95)
    at org.kohsuke.stapler.MetaClass$1.doDispatch(MetaClass.java:111)
    at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:53)
    at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:683)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:776)
    at org.kohsuke.stapler.MetaClass$6.doDispatch(MetaClass.java:239)
    at org.kohsuke.stapler.NameBasedDispatcher.dispatch(NameBasedDispatcher.java:53)
    at org.kohsuke.stapler.Stapler.tryInvoke(Stapler.java:683)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:776)
    at org.kohsuke.stapler.Stapler.invoke(Stapler.java:585)
    at org.kohsuke.stapler.Stapler.service(Stapler.java:216)
    at javax.servlet.http.HttpServlet.service(HttpServlet.java:45)
    at winstone.ServletConfiguration.execute(ServletConfiguration.java:248)
    at winstone.RequestDispatcher.forward(RequestDispatcher.java:333)
    at winstone.RequestDispatcher.doFilter(RequestDispatcher.java:376)
    at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:95)
    at hudson.plugins.greenballs.GreenBallFilter.doFilter(GreenBallFilter.java:58)
    at hudson.util.PluginServletFilter$1.doFilter(PluginServletFilter.java:98)
    at hudson.util.PluginServletFilter.doFilter(PluginServletFilter.java:87)
    at winstone.FilterConfiguration.execute(FilterConfiguration.java:194)
    at winstone.RequestDispatcher.doFilter(RequestDispatcher.java:366)
    at hudson.security.csrf.CrumbFilter.doFilter(CrumbFilter.java:48)
    at winstone.FilterConfiguration.execute(FilterConfiguration.java:194)
    at winstone.RequestDispatcher.doFilter(RequestDispatcher.java:366)
    at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:84)
    at hudson.security.UnwrapSecurityExceptionFilter.doFilter(UnwrapSecurityExceptionFilter.java:51)
    at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
    at org.acegisecurity.ui.ExceptionTranslationFilter.doFilter(ExceptionTranslationFilter.java:124)
    at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
    at org.acegisecurity.providers.anonymous.AnonymousProcessingFilter.doFilter(AnonymousProcessingFilter.java:125)
    at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
    at org.acegisecurity.ui.rememberme.RememberMeProcessingFilter.doFilter(RememberMeProcessingFilter.java:142)
    at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
    at org.acegisecurity.ui.AbstractProcessingFilter.doFilter(AbstractProcessingFilter.java:271)
    at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
    at org.acegisecurity.ui.basicauth.BasicProcessingFilter.doFilter(BasicProcessingFilter.java:174)
    at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
    at jenkins.security.ApiTokenFilter.doFilter(ApiTokenFilter.java:64)
    at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
    at org.acegisecurity.context.HttpSessionContextIntegrationFilter.doFilter(HttpSessionContextIntegrationFilter.java:249)
    at hudson.security.HttpSessionContextIntegrationFilter2.doFilter(HttpSessionContextIntegrationFilter2.java:67)
    at hudson.security.ChainedServletFilter$1.doFilter(ChainedServletFilter.java:87)
    at hudson.security.ChainedServletFilter.doFilter(ChainedServletFilter.java:76)
    at hudson.security.HudsonFilter.doFilter(HudsonFilter.java:164)
    at winstone.FilterConfiguration.execute(FilterConfiguration.java:194)
    at winstone.RequestDispatcher.doFilter(RequestDispatcher.java:366)
    at org.kohsuke.stapler.compression.CompressionFilter.doFilter(CompressionFilter.java:49)
    at winstone.FilterConfiguration.execute(FilterConfiguration.java:194)
    at winstone.RequestDispatcher.doFilter(RequestDispatcher.java:366)
    at hudson.util.CharacterEncodingFilter.doFilter(CharacterEncodingFilter.java:81)
    at winstone.FilterConfiguration.execute(FilterConfiguration.java:194)
    at winstone.RequestDispatcher.doFilter(RequestDispatcher.java:366)
    at winstone.RequestDispatcher.forward(RequestDispatcher.java:331)
    at winstone.RequestHandlerThread.processRequest(RequestHandlerThread.java:227)
    at winstone.RequestHandlerThread.run(RequestHandlerThread.java:150)
    at java.util.concurrent.Executors$RunnableAdapter.call(Unknown Source)
    at java.util.concurrent.FutureTask$Sync.innerRun(Unknown Source)
    at java.util.concurrent.FutureTask.run(Unknown Source)
    at winstone.BoundedExecutorService$1.run(BoundedExecutorService.java:77)
    at java.util.concurrent.ThreadPoolExecutor$Worker.runTask(Unknown Source)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source)
    at java.lang.Thread.run(Unknown Source)
Caused by: org.apache.commons.jelly.JellyTagException: jar:file:/D:/Jenkins/plugins/project-inheritance-1.4.8/WEB-INF/lib/classes.jar!/hudson/plugins/project_inheritance/projects/parameters/InheritableStringParameterReferenceDefinition/index.jelly:37:75: st:include No page found '../InheritableStringParameterDefinition/index.jelly' for class hudson.plugins.project_inheritance.projects.parameters.InheritableStringParameterReferenceDefinition
    at org.kohsuke.stapler.jelly.IncludeTag.doTag(IncludeTag.java:124)
    at org.apache.commons.jelly.impl.TagScript.run(TagScript.java:269)
    at org.apache.commons.jelly.tags.core.CoreTagLibrary$2.run(CoreTagLibrary.java:105)
    at org.kohsuke.stapler.jelly.JellyViewScript.run(JellyViewScript.java:81)
    at org.kohsuke.stapler.jelly.IncludeTag.doTag(IncludeTag.java:146)
    at org.apache.commons.jelly.impl.TagScript.run(TagScript.java:269)
    at org.kohsuke.stapler.jelly.ReallyStaticTagLibrary$1.run(ReallyStaticTagLibrary.java:99)
    at org.apache.commons.jelly.TagSupport.invokeBody(TagSupport.java:161)
    at org.apache.commons.jelly.tags.core.ForEachTag.doTag(ForEachTag.java:150)
    at org.apache.commons.jelly.impl.TagScript.run(TagScript.java:269)
    at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
    at org.kohsuke.stapler.jelly.CallTagLibScript$1.run(CallTagLibScript.java:98)
    at org.apache.commons.jelly.tags.define.InvokeBodyTag.doTag(InvokeBodyTag.java:91)
    at org.apache.commons.jelly.impl.TagScript.run(TagScript.java:269)
    at org.kohsuke.stapler.jelly.ReallyStaticTagLibrary$1.run(ReallyStaticTagLibrary.java:99)
    at org.kohsuke.stapler.jelly.ReallyStaticTagLibrary$1.run(ReallyStaticTagLibrary.java:99)
    at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
    at org.apache.commons.jelly.tags.core.CoreTagLibrary$2.run(CoreTagLibrary.java:105)
    at org.kohsuke.stapler.jelly.CallTagLibScript.run(CallTagLibScript.java:119)
    at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
    at org.kohsuke.stapler.jelly.CallTagLibScript$1.run(CallTagLibScript.java:98)
    at org.apache.commons.jelly.tags.define.InvokeBodyTag.doTag(InvokeBodyTag.java:91)
    at org.apache.commons.jelly.impl.TagScript.run(TagScript.java:269)
    at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
    at org.apache.commons.jelly.tags.core.CoreTagLibrary$1.run(CoreTagLibrary.java:98)
    at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
    at org.apache.commons.jelly.tags.core.CoreTagLibrary$2.run(CoreTagLibrary.java:105)
    at org.kohsuke.stapler.jelly.CallTagLibScript.run(CallTagLibScript.java:119)
    at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
    at org.kohsuke.stapler.jelly.CallTagLibScript$1.run(CallTagLibScript.java:98)
    at org.apache.commons.jelly.tags.define.InvokeBodyTag.doTag(InvokeBodyTag.java:91)
    at org.apache.commons.jelly.impl.TagScript.run(TagScript.java:269)
    at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
    at org.kohsuke.stapler.jelly.ReallyStaticTagLibrary$1.run(ReallyStaticTagLibrary.java:99)
    at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
    at org.kohsuke.stapler.jelly.ReallyStaticTagLibrary$1.run(ReallyStaticTagLibrary.java:99)
    at org.kohsuke.stapler.jelly.ReallyStaticTagLibrary$1.run(ReallyStaticTagLibrary.java:99)
    at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
    at org.kohsuke.stapler.jelly.ReallyStaticTagLibrary$1.run(ReallyStaticTagLibrary.java:99)
    at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
    at org.kohsuke.stapler.jelly.ReallyStaticTagLibrary$1.run(ReallyStaticTagLibrary.java:99)
    at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
    at org.apache.commons.jelly.tags.core.CoreTagLibrary$2.run(CoreTagLibrary.java:105)
    at org.kohsuke.stapler.jelly.CallTagLibScript.run(CallTagLibScript.java:119)
    at org.apache.commons.jelly.impl.ScriptBlock.run(ScriptBlock.java:95)
    at org.apache.commons.jelly.tags.core.CoreTagLibrary$2.run(CoreTagLibrary.java:105)
    at org.kohsuke.stapler.jelly.JellyViewScript.run(JellyViewScript.java:81)
    at org.kohsuke.stapler.jelly.DefaultScriptInvoker.invokeScript(DefaultScriptInvoker.java:63)
    at org.kohsuke.stapler.jelly.DefaultScriptInvoker.invokeScript(DefaultScriptInvoker.java:53)
    at org.kohsuke.stapler.jelly.JellyRequestDispatcher.forward(JellyRequestDispatcher.java:55)
    ... 70 more
