### PR TITLE
Improve caching of calledFromClass methods to avoid repeated calls to the classloader for classes not found

### DIFF
--- a/src/main/java/hudson/plugins/project_inheritance/projects/inheritance/InheritanceGovernor.java
+++ b/src/main/java/hudson/plugins/project_inheritance/projects/inheritance/InheritanceGovernor.java
@@ -420,9 +420,7 @@ public abstract class InheritanceGovernor<T> {
 						Build.class, BuildCommand.class,
 						Queue.class, BuildTrigger.class
 				) ||
-				Reflection.calledFromMethod(InheritanceProject.class, "doBuild") ||
-				Reflection.calledFromMethod(InheritanceProject.class, "scheduleBuild2") ||
-				Reflection.calledFromMethod(InheritanceProject.class, "doBuildWithParameters")) {
+				Reflection.calledFromMethod(InheritanceProject.class, "doBuild", "scheduleBuild2", "doBuildWithParameters")) {
 			return true;
 		}
 		//Another possibility is that the user requested a build page


### PR DESCRIPTION
We faced a lot of threads beeing blocked by the synchronization in the UberClassloader. I extended the caching to use the complete stacktrace frame as cache key. That improved the performance on our Jenkins dramatically.

I also slightly improved the calledFromMethod call to have the getStackTrace() call only once for those three methods to check in InheritanceGovernor.
