### PR TITLE
[FIXED JENKINS-28322] New version not saved when only Promoted builds…

### DIFF
--- a/src/main/java/hudson/plugins/project_inheritance/projects/InheritanceProject.java
+++ b/src/main/java/hudson/plugins/project_inheritance/projects/InheritanceProject.java
@@ -1950,7 +1950,8 @@ public class InheritanceProject	extends Project<InheritanceProject, InheritanceB
 		
 		//Now, we check if this version is the same as the last one
 		Version prev = this.versionStore.getVersion(v.id - 1);
-		if (prev != null && this.versionStore.areIdentical(prev, v)) {
+		//If the new version creation is forced, we save it even if it is the same as the previous one. 
+		if (!ProjectCreationEngine.instance.getForceNewVersion() &&  prev != null && this.versionStore.areIdentical(prev, v)) {
 			//Drop the version, if possible
 			this.versionStore.undoVersion(v);
 		}

--- a/src/main/java/hudson/plugins/project_inheritance/projects/creation/ProjectCreationEngine.java
+++ b/src/main/java/hudson/plugins/project_inheritance/projects/creation/ProjectCreationEngine.java
@@ -404,6 +404,7 @@ public class ProjectCreationEngine extends ManagementLink implements Saveable, D
 	protected boolean enableApplyButton = true;
 	protected String magicNodeLabelForTesting = null;
 	protected boolean unescapeEqualsCharInParams = false; 
+	protected boolean forceNewVersion = false;
 	
 	protected RenameRestriction renameRestriction = RenameRestriction.ALLOW_ALL;
 	
@@ -556,6 +557,12 @@ public class ProjectCreationEngine extends ManagementLink implements Saveable, D
 				this.unescapeEqualsCharInParams = json.getBoolean("unescapeEqualsCharInParams");
 			} catch (JSONException ex) {
 				this.unescapeEqualsCharInParams = false;
+			}
+			
+			try {
+				this.forceNewVersion = json.getBoolean("forceNewVersion");
+			} catch (JSONException ex) {
+				this.forceNewVersion = false;
 			}
 			
 			try {
@@ -1070,6 +1077,10 @@ public class ProjectCreationEngine extends ManagementLink implements Saveable, D
 	
 	public boolean getUnescapeEqualsCharInParams() {
 		return this.unescapeEqualsCharInParams;
+	}
+	
+	public boolean getForceNewVersion(){
+		return this.forceNewVersion;
 	}
 	
 	public boolean getEnableCreation() {

--- a/src/main/resources/hudson/plugins/project_inheritance/projects/creation/ProjectCreationEngine/mainpanel.groovy
+++ b/src/main/resources/hudson/plugins/project_inheritance/projects/creation/ProjectCreationEngine/mainpanel.groovy
@@ -57,6 +57,18 @@ l.main_panel() {
 			) {
 				f.select(field: "triggerInheritance")
 			}
+			f.entry(
+					title: _("Force new version"), 
+					description: 
+						"If enabled forces saving new version every time project is saved even if no changes since last version were detected. "
+						+ "Configuration changes to some plugins (most notably Promoted builds plugin) are stored outside the "
+						+ " owning project's configuration. This renders inheritance plugin unable "
+						+ " to detect version changes (as the project itself did not change) so it will not "
+						+ " create new version of project configuration. This option provides means to create a new version "
+						+ " every time project configuratino is saved, even if there were no changes." 
+			) {
+				f.checkbox(field: "forceNewVersion")
+			}
 		}
 		
 		f.section(title: _("Creation Options")) {


### PR DESCRIPTION
Added new global configuration option forceNewVersion to save new version every time the project is saved, even if there were no changes.
It is actually a work around of the problem. See https://issues.jenkins-ci.org/browse/JENKINS-28322 for more information. 
