### PR TITLE
Blacklist

### DIFF
--- a/src/main/java/hudson/plugins/project_inheritance/projects/inheritance/InheritanceGovernor.java
+++ b/src/main/java/hudson/plugins/project_inheritance/projects/inheritance/InheritanceGovernor.java
@@ -404,6 +404,8 @@ public abstract class InheritanceGovernor<T> {
 	}
 	
 	public static boolean inheritanceLookupRequired(InheritanceProject root, boolean forcedInherit) {
+		//Default to yes, unless there is a compelling reason to not have inheritance lookup. 
+
 		//In a cyclic dependency, any form of inheritance would be ill-advised
 		try {
 			if (root.hasCyclicDependency()) {
@@ -414,49 +416,8 @@ public abstract class InheritanceGovernor<T> {
 			//an NPE which means no inheritance should be queried
 			return false;
 		}
-		/* Otherwise, an exploration is only required when one of the following
-		 * holds:
-		 * 1.) The user wants to force inheritance
-		 * 2.) The project is transient and has no real own configuration
-		 * 3.) The project is called in the context of a build
-		 * 4.) The queue queries properties of the project 
-		 */
 		
-		//Check forced inheritance or transience
-		if (forcedInherit || root.getIsTransient()) {
-			return true;
-		}
-		
-		//Checking the Stapler Request, because it is fast
-		StaplerRequest req = Stapler.getCurrentRequest();
-		if (req != null) {
-			String uri = req.getRequestURI();
-			//Check if we request the build page
-			if (uri.endsWith("/build")) {
-				return true;
-			}
-			//Check if we were requested by page for a run
-			if (runUriRegExp.matcher(uri).matches()) {
-				return true;
-			}
-		}
-		
-		//Check via expensive stack reflection
-		if (Reflection.calledFromClass(
-				Build.class, BuildCommand.class,
-				Queue.class, BuildTrigger.class,
-				Trigger.class, BuildStep.class
-			) ||
-			Reflection.calledFromMethod(
-					InheritanceProject.class,
-					"doBuild", "scheduleBuild2", "doBuildWithParameters"
-			)
-		) {
-			return true;
-		}
-		
-		//In all other cases, we don't require (or want) inheritance
-		return false;
+		return true;
 	}
 	
 	/**

--- a/src/main/java/hudson/plugins/project_inheritance/projects/inheritance/InheritanceGovernor.java
+++ b/src/main/java/hudson/plugins/project_inheritance/projects/inheritance/InheritanceGovernor.java
@@ -423,7 +423,16 @@ public abstract class InheritanceGovernor<T> {
 			//Check if we request the configure page. We don't want to see merged parameters in this case. 
 			if (uri.endsWith("/configure")) { 
 				return false;
-			}
+			}else if (uri.endsWith("/configSubmit")) {
+                                return false;
+                        }else if (uri.endsWith("/child-job-creation-config")) {
+                                return false;
+                        }else if (uri.endsWith("/submitChildJobCreation")) {
+                                return false;
+                        }
+
+
+
 		}
 		
 		return true;

--- a/src/main/java/hudson/plugins/project_inheritance/projects/inheritance/InheritanceGovernor.java
+++ b/src/main/java/hudson/plugins/project_inheritance/projects/inheritance/InheritanceGovernor.java
@@ -416,6 +416,15 @@ public abstract class InheritanceGovernor<T> {
 			//an NPE which means no inheritance should be queried
 			return false;
 		}
+
+		StaplerRequest req = Stapler.getCurrentRequest();
+		if (req != null) {
+			String uri = req.getRequestURI();
+			//Check if we request the configure page. We don't want to see merged parameters in this case. 
+			if (uri.endsWith("/configure")) { 
+				return false;
+			}
+		}
 		
 		return true;
 	}


### PR DESCRIPTION
(This is a replacement of https://github.com/i-m-c/jenkins-inheritance-plugin/pull/37 on a new branch)
This basically reverses the logic of InheritanceGovernor.inheritanceLookupRequired. 
Instead of adding thousands of items to the white list assume that we need inheritance and blacklist places where we don't want it.

Previous behavior proved to be problematic as can be seen as follows: 
1. #12
2. #18

Note that i do not know much about this code and why it was introduced in the first place. All i know that i was struggling to get many workflows working: 
1. SCM did not work. 
2. builds triggered by build workflow did not have inherited parameters. 
3. Trend graphs were not displayed. 
etc.

Comments with explanation why this pull request is a bad idea are welcome.
