### PR TITLE
[JENKINS-19819] Trigger Parameterized Build Defined on Abstract Job is Not Triggered by Concrete Jobs

### DIFF
--- a/src/main/java/hudson/plugins/project_inheritance/projects/inheritance/InheritanceGovernor.java
+++ b/src/main/java/hudson/plugins/project_inheritance/projects/inheritance/InheritanceGovernor.java
@@ -28,6 +28,7 @@ import hudson.model.Queue;
 import hudson.model.Saveable;
 import hudson.model.Descriptor;
 import hudson.model.Project;
+import hudson.model.DependencyGraph;
 import hudson.plugins.project_inheritance.projects.InheritanceProject;
 import hudson.plugins.project_inheritance.projects.InheritanceProject.IMode;
 import hudson.plugins.project_inheritance.projects.references.AbstractProjectReference;
@@ -445,7 +446,8 @@ public abstract class InheritanceGovernor<T> {
 		if (Reflection.calledFromClass(
 				Build.class, BuildCommand.class,
 				Queue.class, BuildTrigger.class,
-				Trigger.class, BuildStep.class
+				Trigger.class, BuildStep.class,
+				DependencyGraph.class
 			) ||
 			Reflection.calledFromMethod(
 					InheritanceProject.class,

--- a/src/main/java/hudson/plugins/project_inheritance/projects/inheritance/InheritanceGovernor.java
+++ b/src/main/java/hudson/plugins/project_inheritance/projects/inheritance/InheritanceGovernor.java
@@ -446,13 +446,13 @@ public abstract class InheritanceGovernor<T> {
 		if (Reflection.calledFromClass(
 				Build.class, BuildCommand.class,
 				Queue.class, BuildTrigger.class,
-				Trigger.class, BuildStep.class,
-				DependencyGraph.class
+				Trigger.class, BuildStep.class
 			) ||
 			Reflection.calledFromMethod(
 					InheritanceProject.class,
 					"doBuild", "scheduleBuild2", "doBuildWithParameters"
-			)
+			) ||
+			Reflection.calledFromMethod(DependencyGraph.class, "build")
 		) {
 			return true;
 		}


### PR DESCRIPTION
The problem is that DependencyGraph instance which used for calling/showing all downstream projects is built at start Jenkins.
